### PR TITLE
Add support for us-east-1

### DIFF
--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -89,5 +89,10 @@ func (s *S3Store) Put(bucket string, path string, content []byte) (*storage.PutR
 
 // GetURL ...
 func (s *S3Store) GetURL(bucket string, path string) string {
-	return fmt.Sprintf("https://s3-%s.amazonaws.com/%s/%s", s.config.Region, bucket, path)
+	domain := fmt.Sprintf("s3-%s.amazonaws.com", s.config.Region)
+	if s.config.Region == "us-east-1" {
+		domain = "s3.amazonaws.com"
+	}
+
+	return fmt.Sprintf("https://%s/%s/%s", domain, bucket, path)
 }


### PR DESCRIPTION
Right now, the urls appears as this
```
- apiVersion: v1
    created: 2017-04-11T16:01:16.329632702-04:00
    description: my cluster
    digest: geragea
    name: my-app
    urls:
    - https://s3-us-east-1.amazonaws.com/myapp-0.5.172.tgz
```
which doesn't work since that domain is supposed to be `s3.amazonaws.com` for us-east-1

This fixes it. This is my first time writing Go so let me know if I should fix anything!

@luizbafilho 