### PR TITLE
GCS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Helm Chart Publisher
 Helm Chart Publisher aims to help you build a nice CI/CD pipeline. It seats in front of a object storage service (such as AWS S3, OpenStack Swift) or a filesystem, sends your charts to it and also updates the index.
 
-After receiving a PUT request with a repository and the chart, the publisher will upload the chart file to your storage, update the index and upload it too. Currently, it supports only Amazon S3, but OpenStack Swift, Google Cloud Storage and Filesystem are planned.
+After receiving a PUT request with a repository and the chart, the publisher will upload the chart file to your storage, update the index and upload it too. Currently, it supports Amazon S3, OpenStack Swift, and Google Cloud Storage. Filesystem storage is planned.
 
 ## Configuration
 The configuration is based on a YAML file. In order to publish your charts, you have to configure a `storage` and one or more `repos` (Helm repositories).
@@ -23,6 +23,7 @@ repos:
     directory: test
 
 storage:
+  gcs: {} # uses GCloud Application Default Credentials
   s3:
     accessKey: AMAZON_ACCESS_KEY
     secretKey: AMAZON_SECRET_KEY
@@ -101,7 +102,7 @@ chmod +x /usr/local/bin/helm-chart-publisher
 ## Roadmap
 - [ ] Storages
   - [x] Openstack Swift
-  - [ ] Google Cloud Storage
+  - [x] Google Cloud Storage
   - [ ] Filesystem
 - [ ] Tests
   - [ ] api
@@ -110,4 +111,4 @@ chmod +x /usr/local/bin/helm-chart-publisher
   
   
 ## Notes
-This project is at a very early stage, suggestions are, as always, very welcome in the form of PR's. If you feel the documentation it's not clear or you have any questions, please open an issue for that.
+This project is at a very early stage, suggestions are, as always, very welcome in the form of PR's. If you feel the documentation is not clear or you have any questions, please open an issue for that.

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/luizbafilho/helm-chart-publisher/cmd"
+	_ "github.com/luizbafilho/helm-chart-publisher/storage/gcs"
 	_ "github.com/luizbafilho/helm-chart-publisher/storage/s3"
 	_ "github.com/luizbafilho/helm-chart-publisher/storage/swift"
 )

--- a/storage/gcs/factory.go
+++ b/storage/gcs/factory.go
@@ -2,12 +2,9 @@ package gcs
 
 import (
 	gcsStorage "cloud.google.com/go/storage"
-	"fmt"
 	"github.com/luizbafilho/helm-chart-publisher/storage"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
-	"os"
 )
 
 func init() {
@@ -21,6 +18,9 @@ func NewGcsStorage(conf map[string]interface{}) (storage.Storage, error) {
 	}
 
 	ctx := context.Background()
+	// requires GCloud "Application Default Credentials" set via
+	//  `gcloud auth application-default login` command or
+	//  GOOGLE_APPLICATION_CREDENTIALS environment variable
 	client, err := gcsStorage.NewClient(ctx)
 
 	return &GcsStore{
@@ -36,24 +36,6 @@ func decodeAndValidateConfig(c map[string]interface{}) (*Config, error) {
 		return nil, err
 	}
 
-	mergeEnviromentVariables(&config)
-
-	if config.GoogleApplicationCredentials == "" {
-		return nil, errors.New("Invalid config. GoogleApplicationCredentials is required.")
-	}
-	if config.Project == "" {
-		return nil, errors.New("Invalid config. Project is required.")
-	}
-	if config.Bucket == "" {
-		return nil, errors.New("Invalid config. Bucket is required.")
-	}
-
 	return &config, nil
 }
 
-func mergeEnviromentVariables(config *Config) {
-	if googleApplicationCredentials := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); googleApplicationCredentials != "" {
-		config.GoogleApplicationCredentials = googleApplicationCredentials
-	}
-
-}

--- a/storage/gcs/factory.go
+++ b/storage/gcs/factory.go
@@ -1,0 +1,58 @@
+package gcs
+
+import (
+	gcsStorage "cloud.google.com/go/storage"
+	"fmt"
+	"github.com/luizbafilho/helm-chart-publisher/storage"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+func init() {
+	storage.Register("gcs", NewGcsStorage)
+}
+
+func NewGcsStorage(conf map[string]interface{}) (storage.Storage, error) {
+	config, err := decodeAndValidateConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	client, err := gcsStorage.NewClient(ctx)
+	fmt.Println("ctx: ", ctx)
+	fmt.Println("client: ", client)
+	fmt.Println("err: ", err)
+
+	return &GcsStore{
+		name:   "gcs",
+		config: config,
+		gcs:    client,
+	}, nil
+}
+
+func decodeAndValidateConfig(c map[string]interface{}) (*Config, error) {
+	config := Config{}
+	if err := mapstructure.Decode(c, &config); err != nil {
+		return nil, err
+	}
+	fmt.Println("c: ", c)
+
+	mergeEnviromentVariables(&config)
+	fmt.Println("config: ", config)
+
+	if config.project == "" {
+		return nil, errors.New("Invalid config. project is required.")
+	}
+	if config.bucket == "" {
+		return nil, errors.New("Invalid config. bucket is required.")
+	}
+
+	return &config, nil
+}
+
+func mergeEnviromentVariables(config *Config) {
+	config.project = "staging-165617"
+	config.bucket = "helm-charts-staging-165617"
+}

--- a/storage/gcs/factory.go
+++ b/storage/gcs/factory.go
@@ -3,7 +3,7 @@ package gcs
 import (
 	gcsStorage "cloud.google.com/go/storage"
 	"github.com/luizbafilho/helm-chart-publisher/storage"
-	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -12,30 +12,17 @@ func init() {
 }
 
 func NewGcsStorage(conf map[string]interface{}) (storage.Storage, error) {
-	config, err := decodeAndValidateConfig(conf)
-	if err != nil {
-		return nil, err
-	}
-
 	ctx := context.Background()
 	// requires GCloud "Application Default Credentials" set via
 	//  `gcloud auth application-default login` command or
 	//  GOOGLE_APPLICATION_CREDENTIALS environment variable
 	client, err := gcsStorage.NewClient(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "[GCS] Client failure")
+	}
 
 	return &GcsStore{
 		name:   "gcs",
-		config: config,
 		gcs:    client,
 	}, nil
 }
-
-func decodeAndValidateConfig(c map[string]interface{}) (*Config, error) {
-	config := Config{}
-	if err := mapstructure.Decode(c, &config); err != nil {
-		return nil, err
-	}
-
-	return &config, nil
-}
-

--- a/storage/gcs/factory.go
+++ b/storage/gcs/factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
+	"os"
 )
 
 func init() {
@@ -21,9 +22,6 @@ func NewGcsStorage(conf map[string]interface{}) (storage.Storage, error) {
 
 	ctx := context.Background()
 	client, err := gcsStorage.NewClient(ctx)
-	fmt.Println("ctx: ", ctx)
-	fmt.Println("client: ", client)
-	fmt.Println("err: ", err)
 
 	return &GcsStore{
 		name:   "gcs",
@@ -37,22 +35,25 @@ func decodeAndValidateConfig(c map[string]interface{}) (*Config, error) {
 	if err := mapstructure.Decode(c, &config); err != nil {
 		return nil, err
 	}
-	fmt.Println("c: ", c)
 
 	mergeEnviromentVariables(&config)
-	fmt.Println("config: ", config)
 
-	if config.project == "" {
-		return nil, errors.New("Invalid config. project is required.")
+	if config.GoogleApplicationCredentials == "" {
+		return nil, errors.New("Invalid config. GoogleApplicationCredentials is required.")
 	}
-	if config.bucket == "" {
-		return nil, errors.New("Invalid config. bucket is required.")
+	if config.Project == "" {
+		return nil, errors.New("Invalid config. Project is required.")
+	}
+	if config.Bucket == "" {
+		return nil, errors.New("Invalid config. Bucket is required.")
 	}
 
 	return &config, nil
 }
 
 func mergeEnviromentVariables(config *Config) {
-	config.project = "staging-165617"
-	config.bucket = "helm-charts-staging-165617"
+	if googleApplicationCredentials := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); googleApplicationCredentials != "" {
+		config.GoogleApplicationCredentials = googleApplicationCredentials
+	}
+
 }

--- a/storage/gcs/gcs.go
+++ b/storage/gcs/gcs.go
@@ -10,15 +10,8 @@ import (
 	"io/ioutil"
 
 )
-
-type Config struct {
-	// for public repos, give allUsers the Storage Object Viewer role for bucket
-	// configuration all done inside of 'Application Default Credentials'
-}
-
 type GcsStore struct {
 	name   string
-	config *Config
 	gcs    *gcsStorage.Client
 }
 

--- a/storage/gcs/gcs.go
+++ b/storage/gcs/gcs.go
@@ -1,0 +1,105 @@
+package gcs
+
+import (
+	"fmt"
+
+	gcsStorage "cloud.google.com/go/storage"
+	"context"
+	"github.com/luizbafilho/helm-chart-publisher/storage"
+	"io/ioutil"
+)
+
+type Config struct {
+	project string
+	bucket  string
+}
+
+type GcsStore struct {
+	name   string
+	config *Config
+	gcs    *gcsStorage.Client
+}
+
+// Name ...
+func (s *GcsStore) Name() string {
+	return s.name
+}
+
+func parseError(err error) error {
+	if s3Err, ok := err.(awserr.Error); ok {
+		switch s3Err.Code() {
+		case "NotModified":
+			return storage.NotModifiedErr{}
+		case "ErrObjectNotExist":
+			return storage.PathNotFoundErr{}
+		}
+	}
+
+	return err
+}
+
+// Get ...
+func (s *GcsStore) Get(bucket string, path string) (*storage.GetResponse, error) {
+	gcsBucket := s.gcs.Bucket(bucket)
+	obj := gcsBucket.Object(path)
+	fmt.Println("gcsBucket: ", gcsBucket)
+	fmt.Println("obj: ", obj)
+
+	ctx := context.Background()
+	fmt.Println("ctx: ", ctx)
+	r, err := obj.NewReader(ctx)
+	fmt.Println("r: ", r)
+	if err != nil {
+		return nil, parseError(err)
+		fmt.Println("R err: ", err)
+		return nil, err
+	}
+	defer r.Close()
+
+	body, err := ioutil.ReadAll(r)
+	fmt.Println("body: ", body)
+	if err != nil {
+		fmt.Println("S err: ", err)
+		return nil, err
+	}
+
+	return &storage.GetResponse{
+		Body: body,
+	}, nil
+}
+
+// Put stores the content
+func (s *GcsStore) Put(bucket string, path string, content []byte) (*storage.PutResponse, error) {
+	// This authentication is done because there is some weird bug when authentication retry
+	// has to happen, making the swift package send a request with zero byte body.
+	// To avoid that, I'm authenticating before the PUT call, to make sure no retry will be need.
+	gcsBucket := s.gcs.Bucket(bucket)
+	fmt.Println("gcsBucket: ", gcsBucket)
+	obj := gcsBucket.Object(path)
+	fmt.Println("obj: ", obj)
+
+	ctx := context.Background()
+	fmt.Println("ctx: ", ctx)
+	w := obj.NewWriter(ctx)
+	fmt.Println("w: ", w)
+
+	w.ObjectAttrs.ContentType = "application/gzip"
+	w.ObjectAttrs.ContentEncoding = "gzip"
+	w.ChunkSize = 65536
+	// Write some text to obj. This will overwrite whatever is there.
+	if _, err := w.Write([]byte("XXXXXXXXXXX")); err != nil {
+		// TODO: Handle error.
+	}
+	// Close, just like writing a file.
+	if err := w.Close(); err != nil {
+		// TODO: Handle error.
+	}
+
+	return &storage.PutResponse{}, nil
+}
+
+// GetURL ...
+func (s *GcsStore) GetURL(bucket string, path string) string {
+	domain := "storage.cloud.google.com"
+	return fmt.Sprintf("%s/%s/%s", domain, bucket, path)
+}

--- a/storage/s3/factory.go
+++ b/storage/s3/factory.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -43,6 +44,7 @@ func decodeAndValidateConfig(c map[string]interface{}) (*Config, error) {
 	if err := mapstructure.Decode(c, &config); err != nil {
 		return nil, err
 	}
+	fmt.Println("config: ", config)
 
 	mergeEnviromentVariables(&config)
 

--- a/storage/s3/factory.go
+++ b/storage/s3/factory.go
@@ -44,7 +44,6 @@ func decodeAndValidateConfig(c map[string]interface{}) (*Config, error) {
 	if err := mapstructure.Decode(c, &config); err != nil {
 		return nil, err
 	}
-	fmt.Println("config: ", config)
 
 	mergeEnviromentVariables(&config)
 

--- a/storage/s3/factory.go
+++ b/storage/s3/factory.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"


### PR DESCRIPTION
Adds support for GCS

Authentication is done via GCloud [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).

Credentials are set via the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, or by running `gcloud auth application-default login`.

For publicly-available GCS-backed Chart repos: set up your GCS bucket like described [here](https://github.com/kubernetes/helm/blob/master/docs/chart_repository.md#google-cloud-storage)

GCS Example config:
```
repos:
  - name: default
    bucket: mybucket123

storage:
  gcs: {}
```
