### PR TITLE
URL as an option for Repo Publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The Helm repository isolation can be done via bucket or a directory. The publish
 
 Each repo requires `name` and `bucket`. You can also specify a `directory`, if you do so, the charts are going to be stored in `bucket` under the specified path.
 
+Finally, you can also specify a `url` in the case you are using a proxy, CDN, etc. to direct traffic to your bucket. This also allows you the ability to add basic authentication in front of your repository in the form of `https://[username]:[password]@[domain]`. You can also specify subdirectories in the path if you so choose. The final output with a specified `url` will be `[url]/[chart|index]`.
+
 These are the configuration options for the helm publisher.
 
 ```
@@ -21,6 +23,7 @@ repos:
   - name: test
     bucket: test-bucket
     directory: test
+    url: https://[username]:[password]@mycharts.com/test
 
 storage:
   gcs: {} # uses GCloud Application Default Credentials

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -154,7 +154,7 @@ func (p *Publisher) createNewIndex(r *Repo, filename string, chartContent []byte
 	if err != nil {
 		return nil, HelmErr{err, "Digest helm chart failed"}
 	}
-	index.Add(chart.Metadata, filename, p.store.GetURL(r.Bucket, r.Directory), hash)
+	index.Add(chart.Metadata, filename, p.store.GetURL(r.Bucket, r.Directory, r.Url), hash)
 
 	return index, nil
 }

--- a/publisher/repo.go
+++ b/publisher/repo.go
@@ -11,6 +11,7 @@ type Repo struct {
 	Name      string
 	Bucket    string
 	Directory string
+	Url       string
 }
 
 // Path ...

--- a/storage/gcs/gcs.go
+++ b/storage/gcs/gcs.go
@@ -70,6 +70,10 @@ func (s *GcsStore) Put(bucket string, path string, content []byte) (*storage.Put
 }
 
 // GetURL ...
-func (s *GcsStore) GetURL(bucket string, path string) string {
-	return fmt.Sprintf("https://%s.storage.googleapis.com/%s", bucket, path)
+func (s *GcsStore) GetURL(bucket string, path string, url string) string {
+	if url != "" {
+		return fmt.Sprintf(url)
+	} else {
+		return fmt.Sprintf("https://%s.storage.googleapis.com/%s", bucket, path)
+	}
 }

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -17,7 +17,6 @@ type Config struct {
 	SecretKey string
 	Bucket    string
 	Region    string
-	Url       string
 }
 
 type S3Store struct {
@@ -85,15 +84,14 @@ func (s *S3Store) Put(bucket string, path string, content []byte) (*storage.PutR
 }
 
 // GetURL ...
-func (s *S3Store) GetURL(bucket string, path string) string {
-	domain := fmt.Sprintf("s3-%s.amazonaws.com", s.config.Region)
-	if s.config.Region == "us-east-1" {
-		domain = "s3.amazonaws.com"
-	}
-
-	if s.config.Url != "" {
-		return fmt.Sprintf(s.config.Url)
+func (s *S3Store) GetURL(bucket string, path string, url string) string {
+	if url != "" {
+		return fmt.Sprintf(url)
 	} else {
+		domain := fmt.Sprintf("s3-%s.amazonaws.com", s.config.Region)
+		if s.config.Region == "us-east-1" {
+			domain = "s3.amazonaws.com"
+		}
 		return fmt.Sprintf("https://%s/%s/%s", domain, bucket, path)
 	}
 }

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -17,6 +17,7 @@ type Config struct {
 	SecretKey string
 	Bucket    string
 	Region    string
+	Url       string
 }
 
 type S3Store struct {
@@ -90,5 +91,9 @@ func (s *S3Store) GetURL(bucket string, path string) string {
 		domain = "s3.amazonaws.com"
 	}
 
-	return fmt.Sprintf("https://%s/%s/%s", domain, bucket, path)
+	if s.config.Url != "" {
+		return fmt.Sprintf(s.config.Url)
+	} else {
+		return fmt.Sprintf("https://%s/%s/%s", domain, bucket, path)
+	}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -21,7 +21,7 @@ type Storage interface {
 	Put(bucket string, path string, content []byte) (*PutResponse, error)
 	Get(bucket string, path string) (*GetResponse, error)
 
-	GetURL(bucket string, directory string) string
+	GetURL(bucket string, directory string, url string) string
 }
 
 // PathNotFoundErr is returned when operating on a nonexistent path.

--- a/storage/swift/swift.go
+++ b/storage/swift/swift.go
@@ -87,6 +87,11 @@ func (s *SwiftStore) Put(bucket string, path string, content []byte) (*storage.P
 }
 
 // GetURL ...
-func (s *SwiftStore) GetURL(bucket string, path string) string {
-	return fmt.Sprintf("%s/%s/%s", s.swift.Auth.StorageUrl(true), bucket, path)
+func (s *SwiftStore) GetURL(bucket string, path string, url string) string {
+	if url != "" {
+		return fmt.Sprintf(url)
+	} else {
+		return fmt.Sprintf("%s/%s/%s", s.swift.Auth.StorageUrl(true), bucket, path)
+	}
 }
+


### PR DESCRIPTION
This is a simple addition to the Helm Chart Publisher that allows for a user to provide a repo specific `url` that can be used to reach a chart repository, rather than the generated url created by Publisher.

A simple use case for this would be if the charts are served via a CDN (i.e. CloudFront), have some form of basic authentication in front of them (in which case the chart index needs the credentials stored for proper downloads via helm), etc.

In `s3.go`, `gcs.go`, and `swift.go`, we perform a simple `if/else` check; if a `url` is not provided for a given repo, it generates the url for the user instead.