### PR TITLE
Add cloud.google.com/go/storage as glide dep

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -22,3 +22,4 @@ import:
 - package: github.com/spf13/afero
 - package: github.com/spf13/cobra
 - package: github.com/ncw/swift
+- package: cloud.google.com/go/storage


### PR DESCRIPTION
Hi,
I'm extremely new to the go ecosystem but when I tried to build the docker container just now, I ran into this message:
`GOOS=linux GOARCH=amd64 go build -o ./dist/helm-chart-publisher_linux-amd64;
storage/gcs/factory.go:4:2: cannot find package "cloud.google.com/go/storage" in any of:
	/root/.jenkins/workspace/gobums/go/src/github.com/luizbafilho/helm-chart-publisher/vendor/cloud.google.com/go/storage (vendor tree)
	/usr/lib/golang/src/cloud.google.com/go/storage (from $GOROOT)
	/root/.jenkins/workspace/gobums/go/src/cloud.google.com/go/storage (from $GOPATH)
make: *** [build-all] Error 1`

I've installed the package with go get and the build went through, I've then tried to verify that adding the package to the dependencies as in this PR causes the problem to disappear in a clean environment.